### PR TITLE
Modify standard error messages of pydantic

### DIFF
--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -1,6 +1,8 @@
+import jsonschema
+import pydantic
 import pytest
+from pathlib import Path
 from nomenclature.region_mapping_models import RegionAggregationMapping
-from jsonschema.exceptions import ValidationError
 
 from conftest import TEST_DATA_DIR
 
@@ -43,32 +45,32 @@ def test_mapping():
     [
         (
             "illegal_mapping_invalid_format_dict.yaml",
-            ValidationError,
+            jsonschema.ValidationError,
             ".*common_region_1.*not.*'array'.*",
         ),
         (
             "illegal_mapping_illegal_attribute.yaml",
-            ValidationError,
+            jsonschema.ValidationError,
             "Additional properties are not allowed.*",
         ),
         (
             "illegal_mapping_conflict_regions.yaml",
-            ValueError,
+            pydantic.ValidationError,
             r".*Conflict between \(renamed\).*common_region_1.*",
         ),
         (
             "illegal_mapping_duplicate_native.yaml",
-            ValueError,
-            ".*Two or more.*alternative_name_a.*",
+            pydantic.ValidationError,
+            ".*Name collision in native regions.*alternative_name_a.*",
         ),
         (
             "illegal_mapping_duplicate_native_rename.yaml",
-            ValueError,
-            ".*Two or more.*alternative_name_a.*",
+            pydantic.ValidationError,
+            ".*Name collision in native regions.*alternative_name_a.*",
         ),
         (
             "illegal_mapping_duplicate_common.yaml",
-            ValueError,
+            pydantic.ValidationError,
             ".*common regions.*common_region_1.*",
         ),
     ],


### PR DESCRIPTION
Proposed modification of the standard error message for ValidationErrors from pydantic to include the file name(s) where errors originated. 
The original error message is as follows:
```python
ValidationError: 1 validation error for RegionAggregationMapping
__root__
  Conflict between (renamed) native regions and aggregation mapping to common regions: ['common_region_1'] in tests/data/region_aggregation/illegal_mapping_conflict_regions.yaml (type=value_error)
```
The goal was to get this:
```python
ValidationError: 1 validation error for RegionAggregationMapping in `region_aggregation/illegal_mapping_conflict_regions.yaml`:
__root__
  Conflict between (renamed) native regions and aggregation mapping to common regions: ['common_region_1' (type=value_error)
```

In order to achieve this behavior we must first understand the structure of pydantic error handling.
As far as I understand it, pydantic collects all errors raised during validation and then raises them together in a single error wrapping class called [`ValidationError`](https://github.com/samuelcolvin/pydantic/blob/master/pydantic/error_wrappers.py#L50). The individual errors raised in the validators should **not** be ValidationErrors but instead `ValueError`, `TypeError` or `AssertionError` (see [documentation](https://pydantic-docs.helpmanual.io/usage/models/#error-handling) for details). 
This is what makes changing the error message tricky because in this two tier error structure we can usually only influence the layer of Value- Type- or AssertionErrors and not of the wrapper ValidationError.
Looking into the source of `ValidationError`, the behavior of [`ValidationError.__str__`](https://github.com/samuelcolvin/pydantic/blob/master/pydantic/error_wrappers.py#L70) would need to be modified. 
Luckily, altering the behavior of a certain object in python even if the object in question is imported from a third party library (see [this stackoverflow post](https://stackoverflow.com/questions/19545982/monkey-patching-a-class-in-another-module-in-python) for details). This is called monkey-patching. As `__str__` is a special ('dunder') method we can only monkey patch it on the class and not on the individual instance level (see [this stackoverflow post](https://stackoverflow.com/questions/60062100/is-it-possible-to-override-a-class-call-method)).
However, monkey patching a function as fundamental as `__str__` is potentially dangerous as it could break compatibility if changes are made upstream. Therefore, I opted to deep copy the original string method and only add functionality while still mostly using the original.
The second piece of the puzzle is getting the information about the file from the lower level of the ValueError to the higher wrapper class ValidationError. In order to make this easier I created a custom error ([pydantic documentation](https://pydantic-docs.helpmanual.io/usage/models/#custom-errors)). To keep things as simple as possible I've only created one custom error so far `DoubleNativeRegionError(PydanticValueError)`. As this error is invoked it is handed a file parameter which is then used in the modified `ValidationError.__str__` to produce the desired output.

At the end of `region_mapping_models.py` I have put an example that illustrates the newly formatted error.

Would love to hear your thoughts @danielhuppmann.
Also @meksor, would be cool to hear what you think about it. Is this complete overkill or closer to the minimum necessary to achieve the desired behavior?