### PR TITLE
Move validation of RegionProcessor and RequireVariableProcessor to DataStructureDefinition

### DIFF
--- a/nomenclature/code.py
+++ b/nomenclature/code.py
@@ -136,6 +136,7 @@ class VariableCode(Code):
     method: Optional[str] = None
     check_aggregate: Optional[bool] = Field(False, alias="check-aggregate")
     components: Optional[Union[List[str], List[Dict[str, List[str]]]]] = None
+    drop_negative_weights: Optional[bool] = None
 
     class Config:
         # this allows using both "check_aggregate" and "check-aggregate" for attribute
@@ -152,4 +153,26 @@ class VariableCode(Code):
             super()
             .named_attributes()
             .union(f.alias for f in cls.__dict__["__fields__"].values())
+        )
+
+    @property
+    def pyam_agg_kwargs(self) -> Dict[str, Any]:
+        # return a dict of all not None pyam aggregation properties
+        return {
+            field: getattr(self, field)
+            for field in (
+                "components",
+                "method",
+                "weight",
+                "drop_negative_weights",
+            )
+            if getattr(self, field) is not None
+        }
+
+    @property
+    def agg_kwargs(self) -> Dict[str, Any]:
+        return (
+            {**self.pyam_agg_kwargs, **{"region_aggregation": self.region_aggregation}}
+            if self.region_aggregation is not None
+            else self.pyam_agg_kwargs
         )

--- a/nomenclature/core.py
+++ b/nomenclature/core.py
@@ -58,15 +58,15 @@ def process(
     # perform validation and region-processing (optional)
     if processor is None:
         dsd.validate(df, dimensions=dimensions)
+    elif "region" in dimensions:
+        dsd.validate_RegionProcessor(processor)
+        dimensions.remove("region")
+        dsd.validate(df, dimensions=dimensions)
+        df = processor.apply(df, dsd.variable)
+        dsd.validate(df, dimensions=["region"])
     else:
-        if "region" in dimensions:
-            dimensions.remove("region")
-            dsd.validate(df, dimensions=dimensions)
-            df = processor.apply(df, dsd)
-            dsd.validate(df, dimensions=["region"])
-        else:
-            dsd.validate(df, dimensions=dimensions)
-            df = processor.apply(df, dsd)
+        dsd.validate(df, dimensions=dimensions)
+        df = processor.apply(df, dsd.variable)
 
     # check consistency across the variable hierarchy
     error = dsd.check_aggregate(df)

--- a/nomenclature/processor/region.py
+++ b/nomenclature/processor/region.py
@@ -13,17 +13,13 @@ from pydantic import BaseModel, root_validator, validate_arguments, validator
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.types import DirectoryPath, FilePath
 
-from nomenclature.codelist import PYAM_AGG_KWARGS
-from nomenclature.definition import DataStructureDefinition
+from nomenclature.codelist import VariableCodeList
 from nomenclature.error.region import (
     ExcludeRegionOverlapError,
     ModelMappingCollisionError,
     RegionNameCollisionError,
-    RegionNotDefinedError,
 )
 from nomenclature.processor.utils import get_relative_path
-
-AGG_KWARGS = PYAM_AGG_KWARGS + ["region_aggregation"]
 
 logger = logging.getLogger(__name__)
 
@@ -287,11 +283,27 @@ class RegionAggregationMapping(BaseModel):
     def rename_mapping(self) -> Dict[str, str]:
         return {r.name: r.target_native_region for r in self.native_regions or []}
 
-    def validate_regions(self, dsd: DataStructureDefinition) -> None:
-        if hasattr(dsd, "region"):
-            invalid = [c for c in self.all_regions if c not in dsd.region]
-            if invalid:
-                raise RegionNotDefinedError(region=invalid, file=self.file)
+    def check_unexpected_regions(self, df: IamDataFrame) -> None:
+        # Raise value error if a region in the input data is not mentioned in the model
+        # mapping
+
+        if regions_not_found := set(df.region) - set(
+            self.model_native_region_names
+            + self.common_region_names
+            + [
+                const_reg
+                for comm_reg in self.common_regions or []
+                for const_reg in comm_reg.constituent_regions
+            ]
+            + (self.exclude_regions or [])
+        ):
+            raise ValueError(
+                f"Did not find region(s) {regions_not_found} in 'native_regions', "
+                "'common_regions' or 'exclude_regions' in model mapping for "
+                f"{self.model} in {self.file}. If they are not meant to be included "
+                "in the results add to the 'exclude_regions' section in the model "
+                "mapping to silence this error."
+            )
 
 
 class RegionProcessor(BaseModel):
@@ -345,27 +357,17 @@ class RegionProcessor(BaseModel):
             raise pydantic.ValidationError(errors, model=RegionProcessor)
         return cls(mappings=mapping_dict)
 
-    def validate_with_definition(self, dsd: DataStructureDefinition) -> None:
-        """Check if all mappings are valid and collect all errors."""
-        errors = []
-        for mapping in self.mappings.values():
-            try:
-                mapping.validate_regions(dsd)
-            except RegionNotDefinedError as rnde:
-                errors.append(ErrorWrapper(rnde, f"mappings -> {mapping.model}"))
-        if errors:
-            raise pydantic.ValidationError(errors, model=self.__class__)
-
-    def apply(self, df: IamDataFrame, dsd: DataStructureDefinition) -> IamDataFrame:
+    def apply(
+        self, df: IamDataFrame, variablecodelist: VariableCodeList
+    ) -> IamDataFrame:
         """Apply region processing
 
         Parameters
         ----------
         df : IamDataFrame
             Input data that the region processing is applied to
-        dsd : DataStructureDefinition
-            Used for region validation and variable information for performing region
-            processing
+        variablecodelist : VariableCodeList
+            Used for variable information for performing region processing
 
         Returns
         -------
@@ -389,14 +391,12 @@ class RegionProcessor(BaseModel):
 
             # Otherwise we first rename, then aggregate
             else:
-                # before aggregating, check that all regions are valid
-                self.mappings[model].validate_regions(dsd)
                 logger.info(
                     f"Applying region-processing for model {model} from file "
                     f"{self.mappings[model].file}"
                 )
                 # Check for regions not mentioned in the model mapping
-                _check_unexpected_regions(model_df, self.mappings[model])
+                self.mappings[model].check_unexpected_regions(model_df)
                 _processed_dfs = []
 
                 # Silence pyam's empty filter warnings
@@ -413,16 +413,6 @@ class RegionProcessor(BaseModel):
 
                     # Aggregate
                     if self.mappings[model].common_regions is not None:
-                        vars = self._filter_dict_args(model_df.variable, dsd)
-                        vars_default_args = [
-                            var for var, kwargs in vars.items() if not kwargs
-                        ]
-                        # TODO skip if required weight does not exist
-                        vars_kwargs = {
-                            var: kwargs
-                            for var, kwargs in vars.items()
-                            if var not in vars_default_args
-                        }
                         for cr in self.mappings[model].common_regions:
                             # If the common region is only comprised of a single model
                             # native region, just rename
@@ -437,36 +427,46 @@ class RegionProcessor(BaseModel):
                             regions = [cr.name, cr.constituent_regions]
                             # First, perform 'simple' aggregation (no arguments)
                             _processed_dfs.append(
-                                model_df.aggregate_region(vars_default_args, *regions)
+                                model_df.aggregate_region(
+                                    [
+                                        var.name
+                                        for var in variablecodelist.vars_default_args(
+                                            df.variable
+                                        )
+                                    ],
+                                    *regions,
+                                )
                             )
                             # Second, special weighted aggregation
-                            for var, kwargs in vars_kwargs.items():
-                                if "region_aggregation" not in kwargs:
+                            for var in variablecodelist.vars_kwargs(df.variable):
+                                if var.region_aggregation is None:
                                     _df = _aggregate_region(
                                         model_df,
-                                        var,
+                                        var.name,
                                         *regions,
-                                        **kwargs,
+                                        **var.pyam_agg_kwargs,
                                     )
                                     if _df is not None and not _df.empty:
                                         _processed_dfs.append(_df)
                                 else:
-                                    for rename_var in kwargs["region_aggregation"]:
+                                    for rename_var in var.region_aggregation:
                                         for _rename, _kwargs in rename_var.items():
                                             _df = _aggregate_region(
                                                 model_df,
-                                                var,
+                                                var.name,
                                                 *regions,
                                                 **_kwargs,
                                             )
                                             if _df is not None and not _df.empty:
                                                 _processed_dfs.append(
-                                                    _df.rename(variable={var: _rename})
+                                                    _df.rename(
+                                                        variable={var.name: _rename}
+                                                    )
                                                 )
 
                     common_region_df = model_df.filter(
                         region=self.mappings[model].common_region_names,
-                        variable=dsd.variable,
+                        variable=variablecodelist,
                     )
 
                     # concatenate and merge with data provided at common-region level
@@ -487,21 +487,8 @@ class RegionProcessor(BaseModel):
 
         return pyam.concat(processed_dfs)
 
-    def _filter_dict_args(
-        self, variables, dsd: DataStructureDefinition, keys: Set[str] = AGG_KWARGS
-    ) -> Dict[str, Dict]:
-        return {
-            name: {
-                key: value
-                for key, value in code.dict().items()
-                if key in keys and value is not None
-            }
-            for name, code in dsd.variable.items()
-            if name in variables and not code.skip_region_aggregation
-        }
 
-
-def _aggregate_region(df, var, *regions, **kwargs):
+def _aggregate_region(df: IamDataFrame, var: str, *regions, **kwargs) -> IamDataFrame:
     """Perform region aggregation with kwargs catching inconsistent-index errors"""
     try:
         return df.aggregate_region(var, *regions, **kwargs)
@@ -548,28 +535,3 @@ def _check_exclude_region_overlap(values: Dict, region_type: str) -> Dict:
             region=overlap, region_type=region_type, file=values["file"]
         )
     return values
-
-
-def _check_unexpected_regions(
-    df: IamDataFrame, mapping: RegionAggregationMapping
-) -> None:
-    # Raise value error if a region in the input data is not mentioned in the model
-    # mapping
-
-    if regions_not_found := set(df.region) - set(
-        mapping.model_native_region_names
-        + mapping.common_region_names
-        + [
-            const_reg
-            for comm_reg in mapping.common_regions or []
-            for const_reg in comm_reg.constituent_regions
-        ]
-        + (mapping.exclude_regions or [])
-    ):
-        raise ValueError(
-            f"Did not find region(s) {regions_not_found} in 'native_regions', "
-            "'common_regions' or 'exclude_regions' in model mapping for "
-            f"{mapping.model} in {mapping.file}. If they are not meant to be included "
-            "in the results add to the 'exclude_regions' section in the model mapping "
-            "to silence this error."
-        )

--- a/nomenclature/processor/requiredData.py
+++ b/nomenclature/processor/requiredData.py
@@ -1,16 +1,13 @@
 import logging
 from pathlib import Path
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union
 
 import yaml
 from pyam import IamDataFrame
-import pydantic
 from pydantic import BaseModel, validator
-from pydantic.error_wrappers import ErrorWrapper
 
-from nomenclature.definition import DataStructureDefinition
-from nomenclature.processor.utils import get_relative_path
 from nomenclature.error.requiredData import RequiredDataMissingError
+from nomenclature.processor.utils import get_relative_path
 
 logger = logging.getLogger(__name__)
 
@@ -25,56 +22,6 @@ class RequiredData(BaseModel):
     @validator("variable", "region", "year", pre=True)
     def single_input_to_list(cls, v):
         return v if isinstance(v, list) else [v]
-
-    def validate_with_definition(self, dsd: DataStructureDefinition) -> None:
-        error_msg = ""
-
-        # check for undefined regions and variables
-        for dim in ("region", "variable"):
-            if not_defined_dims := self._undefined_dimension(dim, dsd):
-                error_msg += (
-                    f"The following {dim}(s) were not found in the "
-                    f"DataStructureDefinition:\n{not_defined_dims}\n"
-                )
-        # check for defined variables with wrong units
-        if wrong_unit_variables := self._wrong_unit_variables(dsd):
-            error_msg += (
-                "The following variables were found in the "
-                "DataStructureDefinition but have the wrong unit "
-                "(affected variable, wrong unit, expected unit):\n"
-                f"{wrong_unit_variables}"
-            )
-
-        if error_msg:
-            raise ValueError(error_msg)
-
-    def _undefined_dimension(
-        self, dimension: str, dsd: DataStructureDefinition
-    ) -> List[str]:
-        missing_items: List[str] = []
-        # only check if both the current instance and the DataStructureDefinition
-        # have the dimension in question
-        if getattr(self, dimension) and hasattr(dsd, dimension):
-            missing_items.extend(
-                dim
-                for dim in getattr(self, dimension)
-                if dim not in getattr(dsd, dimension)
-            )
-
-        return missing_items
-
-    def _wrong_unit_variables(
-        self, dsd: DataStructureDefinition
-    ) -> List[Tuple[str, str, str]]:
-        wrong_units: List[Tuple[str, str, str]] = []
-        if hasattr(dsd, "variable"):
-            wrong_units.extend(
-                (var, self.unit, getattr(dsd, "variable")[var].unit)
-                for var in getattr(self, "variable")
-                if self.unit and self.unit not in getattr(dsd, "variable")[var].units
-            )
-
-        return wrong_units
 
 
 class RequiredDataValidator(BaseModel):
@@ -114,27 +61,3 @@ class RequiredDataValidator(BaseModel):
                         f"{get_relative_path(self.file)} missing for:\n{missing_index}"
                     )
         return df
-
-    def validate_with_definition(self, dsd: DataStructureDefinition) -> None:
-
-        errors = []
-        for field, value in (
-            (field, getattr(self, field))
-            for field in ("required_data", "optional_data")
-            if getattr(self, field) is not None
-        ):
-            for i, data in enumerate(value):
-                try:
-                    data.validate_with_definition(dsd)
-                except ValueError as ve:
-                    errors.append(
-                        ErrorWrapper(
-                            ve,
-                            (
-                                f"In file {get_relative_path(self.file)}\n{field} "
-                                f"entry nr. {i+1}"
-                            ),
-                        )
-                    )
-        if errors:
-            raise pydantic.ValidationError(errors, model=self.__class__)

--- a/nomenclature/testing.py
+++ b/nomenclature/testing.py
@@ -92,12 +92,12 @@ def assert_valid_structure(
     definition = DataStructureDefinition(path / definitions, dimensions)
     if mappings is None:
         if (path / "mappings").is_dir():
-            RegionProcessor.from_directory(path / "mappings").validate_with_definition(
-                definition
+            definition.validate_RegionProcessor(
+                RegionProcessor.from_directory(path / "mappings")
             )
     elif (path / mappings).is_dir():
-        RegionProcessor.from_directory(path / mappings).validate_with_definition(
-            definition
+        definition.validate_RegionProcessor(
+            RegionProcessor.from_directory(path / mappings)
         )
     else:
         raise FileNotFoundError(f"Mappings directory not found: {path / mappings}")

--- a/tests/test_region_aggregation.py
+++ b/tests/test_region_aggregation.py
@@ -154,9 +154,11 @@ def test_region_processor_not_defined(simple_definition):
         "region_not_defined"
     )
     with pytest.raises(pydantic.ValidationError, match=error_msg):
-        RegionProcessor.from_directory(
-            TEST_DATA_DIR / "regionprocessor_not_defined"
-        ).validate_with_definition(simple_definition)
+        simple_definition.validate_RegionProcessor(
+            RegionProcessor.from_directory(
+                TEST_DATA_DIR / "regionprocessor_not_defined"
+            )
+        )
 
 
 def test_region_processor_duplicate_model_mapping():

--- a/tests/test_requiredData.py
+++ b/tests/test_requiredData.py
@@ -45,7 +45,7 @@ def test_RequiredDataValidator_validate_with_definition():
     dsd = DataStructureDefinition(
         TEST_DATA_DIR / "requiredData" / "definition", dimensions=["region", "variable"]
     )
-    assert rdv.validate_with_definition(dsd) is None
+    assert dsd.validate_RequiredDataValidator(rdv) is None
 
 
 @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ def test_RequiredDataValidator_validate_with_definition_raises(requiredDataFile,
     )
 
     with pytest.raises(ValueError, match=match):
-        rdv.validate_with_definition(dsd)
+        dsd.validate_RequiredDataValidator(rdv)
 
 
 def test_RequiredData_apply(simple_df):


### PR DESCRIPTION
As discussed in iamconsortium/nomenclature#205 I went and moved the validators for the `RegionProcessor` and the `RequireVariableProcessor` class into `DataStructureDefinition`. 
While I was there I did some clean-up and removed some artifacts that were left from before we had the `Code` and more specifically the `VariableCode` and `VariableCodeList` classes. 
This set of changes is related to iamconsortium/nomenclature#205 but I opted to open another branch to be merged into iamconsortium/nomenclature#205 for easier review of the changes.

Among the things changed I found that we forgot to make `drop_negative_weights` a named attribute of the `VariableCode` class. The fact that everything still worked fine shows that the `Code` class works as expected but I added it for consistency. 